### PR TITLE
Fix CI pipeline to not deploy unless pushing to `master`

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -22,9 +22,6 @@ jobs:
         # node-version: [10.x, 12.x, 14.x, 15.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
-    env:
-      IS_PUSH_TO_MASTER: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
-
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
@@ -65,7 +62,6 @@ jobs:
     - name: Deploy (if merging to `master`)
       # reference: https://kevsoft.net/2020/06/10/running-github-action-steps-and-jobs-only-on-push-to-master.html
       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
-#      if: ${{ env.IS_PUSH_TO_MASTER }}
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -64,7 +64,8 @@ jobs:
 
     - name: Deploy (if merging to `master`)
       # reference: https://kevsoft.net/2020/06/10/running-github-action-steps-and-jobs-only-on-push-to-master.html
-      if: ${{ env.IS_PUSH_TO_MASTER }}
+      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+#      if: ${{ env.IS_PUSH_TO_MASTER }}
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Updated `.github/workflows/node.js.yml` to avoid `deploy` steps when not pushing to `master`)