### PR TITLE
Fix `scrollspy` 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hey-personal-portfolio",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "private": true,
   "dependencies": {
     "@material-ui/core": "4.11.3",

--- a/src/components/page/DrawerItemsWithScrollspy.tsx
+++ b/src/components/page/DrawerItemsWithScrollspy.tsx
@@ -38,6 +38,11 @@ const styles = (theme: Theme) => createStyles({
     },
     oldVersionLinkButton: {
         margin: "5%"
+    },
+    isCurrent: {
+        fontWeight: "bolder",
+        color: "#770077",
+        backgroundColor: "#dadaff"
     }
 });
 
@@ -51,8 +56,8 @@ function DrawerItemsWithScrollspy(props: DrawerItemsWithScrollspyProps) {
     return (
         <React.Fragment>
             <Scrollspy
-                items={items}
-                currentClassName="is-current"
+                items={items.map(item => item.toLowerCase())}  // TODO: refactor this
+                currentClassName={classes.isCurrent}
                 className={classes.scrollSpyList}
             >
                 {items.map((text, index) => (

--- a/src/components/page/DrawerItemsWithScrollspy.tsx
+++ b/src/components/page/DrawerItemsWithScrollspy.tsx
@@ -50,6 +50,8 @@ interface DrawerItemsWithScrollspyProps extends WithStyles<typeof styles> {
     items: string[],
 }
 
+const EMPIRICAL_OFFSET = -80;
+
 function DrawerItemsWithScrollspy(props: DrawerItemsWithScrollspyProps) {
     const {items, classes} = props;
 
@@ -59,6 +61,7 @@ function DrawerItemsWithScrollspy(props: DrawerItemsWithScrollspyProps) {
                 items={items.map(item => item.toLowerCase())}  // TODO: refactor this
                 currentClassName={classes.isCurrent}
                 className={classes.scrollSpyList}
+                offset={EMPIRICAL_OFFSET}
             >
                 {items.map((text, index) => (
                     <a key={text} href={itemToHref(text)} className={classes.scrollSpyListItem}>


### PR DESCRIPTION
Fixed the scroll spy at `<DrawerItemsWithScrollspy/>`, after this fix, the current section would be highlighted at the drawer