### PR TITLE
Attempt to fix Google Analytics 4

### DIFF
--- a/src/services/GoogleAnalyticsScripts.tsx
+++ b/src/services/GoogleAnalyticsScripts.tsx
@@ -17,8 +17,11 @@ export const GoogleAnalyticsScripts = () => {
         // reference https://nextjs.org/docs/messages/next-script-for-ga
         return (
             <>
-                <Script src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`} />
-                <Script id="google-analytics">
+                <Script
+                    src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
+                    strategy="beforeInteractive"
+                />
+                <Script id="google-analytics" strategy="beforeInteractive">
                     {`
           window.dataLayer = window.dataLayer || [];
           function gtag(){dataLayer.push(arguments);}


### PR DESCRIPTION
added `strategy="beforeInteractive"` for `GoogleAnalyticsScripts` (reference: https://nextjs.org/docs/app/api-reference/components/script#strategy)