### PR TITLE
Remove `node 16` from `GitHub` `actions`

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 16.x]
+        node-version: [18.x, 20.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:


### PR DESCRIPTION
Updated `.github/workflows/node.js.yml` to remove `16.x` from `node-version`

Reason: [`node 16` is already EOL from `2023-September-11`](https://nodejs.org/en/blog/announcements/nodejs16-eol), and the current versions are `node 18` (LTS) and `node 20` (current) only.